### PR TITLE
Add looping video previews to catalog slot cards

### DIFF
--- a/feature/catalog/api/src/main/kotlin/com/archstarter/feature/catalog/api/CatalogContracts.kt
+++ b/feature/catalog/api/src/main/kotlin/com/archstarter/feature/catalog/api/CatalogContracts.kt
@@ -14,6 +14,7 @@ data class SlotCardState(
     val slot: DaySlot,
     val title: String,
     val videoLabel: String?,
+    val videoUri: Uri?,
     val description: String,
 )
 

--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
@@ -94,6 +94,7 @@ class WallpaperHomeViewModel @AssistedInject constructor(
                 slot = slot,
                 title = slot.displayName,
                 videoLabel = config?.videoLabel,
+                videoUri = config?.videoUri,
                 description = description,
             )
         }


### PR DESCRIPTION
## Summary
- surface each slot's selected video URI through `SlotCardState`
- render a looping, muted video preview inside catalog cards when a video is assigned
- keep wallpaper state mapping in sync with the new preview information

## Testing
- ./gradlew --console=plain --no-daemon :feature:catalog:ui:compileDebugKotlin *(fails: missing Android SDK Build-Tools 35 download)*

------
https://chatgpt.com/codex/tasks/task_e_68e115e05c0c8328a676f76871d36db2