### PR TITLE
Prevent crash when reopening schedules

### DIFF
--- a/app/src/main/java/com/archstarter/app/NavigationActions.kt
+++ b/app/src/main/java/com/archstarter/app/NavigationActions.kt
@@ -13,7 +13,9 @@ class NavigationActions(
 ) : NavigationActionsApi {
 
     override fun openSettings() {
-        navController.navigate(Settings)
+        navController.navigate(Settings) {
+            launchSingleTop = true
+        }
     }
 
     override fun openLink(url: String) {


### PR DESCRIPTION
## Summary
- ensure the settings screen is only pushed once onto the back stack by using launchSingleTop when navigating

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e118a8e5948328beea71a1d2e965cb