### PR TITLE
Make wallpaper home header scrollable and remove action bar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
   implementation(libs.activity.compose)
   implementation(libs.compose.ui)
   implementation(libs.compose.material3)
+  implementation(libs.material)
   implementation(libs.compose.preview)
   debugImplementation(libs.compose.tooling)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:label="DayNight Video Wallpaper">
+        android:label="DayNight Video Wallpaper"
+        android:theme="@style/Theme.DayNightVideoWallpaper">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.DayNightVideoWallpaper" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    </style>
+</resources>

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.widget.VideoView
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -67,84 +68,83 @@ private fun WallpaperHomeContent(
         }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 24.dp),
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Text(
-            text = "DayNight Video Wallpaper",
-            style = MaterialTheme.typography.headlineSmall,
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text = "Assign immersive videos to each part of the day and let them fade in as time moves.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(24.dp))
-        LazyColumn(
-            modifier = Modifier.weight(1f, fill = true),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            items(state.slots, key = { it.slot }) { slotState ->
-                SlotCard(
-                    state = slotState,
-                    onPick = {
-                        pendingSlot = slotState.slot
-                        videoPicker.launch(arrayOf("video/*"))
-                    },
-                    onRemove = { presenter.onRemoveVideo(slotState.slot) },
+        item {
+            Column {
+                Text(
+                    text = "DayNight Video Wallpaper",
+                    style = MaterialTheme.typography.headlineSmall,
                 )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Assign immersive videos to each part of the day and let them fade in as time moves.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
             }
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        }
+        items(state.slots, key = { it.slot }) { slotState ->
+            SlotCard(
+                state = slotState,
+                onPick = {
+                    pendingSlot = slotState.slot
+                    videoPicker.launch(arrayOf("video/*"))
+                },
+                onRemove = { presenter.onRemoveVideo(slotState.slot) },
+            )
+        }
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Text("Playback")
-                        ToggleRow(
-                            title = "Mute audio",
-                            checked = state.mutePlayback,
-                            onToggle = { presenter.onToggleMute() },
-                        )
-                        ToggleRow(
-                            title = "Loop videos",
-                            checked = state.loopPlayback,
-                            onToggle = { presenter.onToggleLoop() },
-                        )
-                    }
+                    Text("Playback")
+                    ToggleRow(
+                        title = "Mute audio",
+                        checked = state.mutePlayback,
+                        onToggle = { presenter.onToggleMute() },
+                    )
+                    ToggleRow(
+                        title = "Loop videos",
+                        checked = state.loopPlayback,
+                        onToggle = { presenter.onToggleLoop() },
+                    )
                 }
             }
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
+        }
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    Text("Schedule", style = MaterialTheme.typography.titleMedium)
+                    Text(state.scheduleSummary, style = MaterialTheme.typography.bodyMedium)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Text("Schedule", style = MaterialTheme.typography.titleMedium)
-                        Text(state.scheduleSummary, style = MaterialTheme.typography.bodyMedium)
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Button(onClick = presenter::onOpenSettings) {
-                                Text("Adjust schedule")
-                            }
-                            TextButton(onClick = presenter::onSetWallpaper) {
-                                Text("Set live wallpaper")
-                            }
+                        Button(onClick = presenter::onOpenSettings) {
+                            Text("Adjust schedule")
+                        }
+                        TextButton(onClick = presenter::onSetWallpaper) {
+                            Text("Set live wallpaper")
                         }
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 [libraries]
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-material3 = { module = "androidx.compose.material3:material3", version = "1.3.2" }
+material = { module = "com.google.android.material:material", version = "1.12.0" }
 compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }


### PR DESCRIPTION
## Summary
- apply a no-action-bar app theme to remove the black action bar from the catalog screen
- move the wallpaper home header into the lazy list so it scrolls with the rest of the content

## Testing
- `./gradlew --version`
- Attempted `./gradlew lint` (cancelled after extended runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e1194219c083288a0d0405ec0aaafa