### PR TITLE
Add timer-based rotating wallpaper schedule

### DIFF
--- a/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/RotationInterval.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/RotationInterval.kt
@@ -1,0 +1,45 @@
+package com.archstarter.core.common.wallpaper
+
+/**
+ * Defines how frequently the wallpaper should advance to the next [DaySlot] when using
+ * [WallpaperScheduleMode.ROTATING].
+ */
+data class RotationInterval(
+    val value: Int = 6,
+    val unit: RotationIntervalUnit = RotationIntervalUnit.HOURS,
+) {
+    init {
+        require(value > 0) { "Rotation interval value must be greater than zero" }
+    }
+
+    /**
+     * Converts this interval to minutes.
+     */
+    val minutes: Int
+        get() = unit.toMinutes(value)
+}
+
+/**
+ * Units that a [RotationInterval] can be expressed in.
+ */
+enum class RotationIntervalUnit {
+    MINUTES,
+    HOURS,
+    DAYS;
+
+    internal fun toMinutes(value: Int): Int {
+        val minutes = when (this) {
+            MINUTES -> value.toLong()
+            HOURS -> value.toLong() * 60
+            DAYS -> value.toLong() * 24 * 60
+        }
+        return minutes.coerceIn(1L, Int.MAX_VALUE.toLong()).toInt()
+    }
+
+    val displayName: String
+        get() = when (this) {
+            MINUTES -> "minutes"
+            HOURS -> "hours"
+            DAYS -> "days"
+        }
+}

--- a/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/WallpaperScheduleMode.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/WallpaperScheduleMode.kt
@@ -14,4 +14,9 @@ enum class WallpaperScheduleMode {
      * Use explicit user-defined start times for every slot.
      */
     FIXED,
+
+    /**
+     * Rotate through slots at a fixed interval regardless of time of day.
+     */
+    ROTATING,
 }

--- a/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/WallpaperSettings.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/wallpaper/WallpaperSettings.kt
@@ -28,6 +28,7 @@ data class WallpaperSettings(
     val scheduleMode: WallpaperScheduleMode = WallpaperScheduleMode.SOLAR,
     val slotConfigurations: Map<DaySlot, SlotConfiguration> = DaySlot.values().associateWith { SlotConfiguration(it, null) },
     val slotSchedules: Map<DaySlot, Int> = defaultSlotSchedule,
+    val rotationInterval: RotationInterval = RotationInterval(),
     val mutePlayback: Boolean = true,
     val loopPlayback: Boolean = true,
 ) {

--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
@@ -12,6 +12,7 @@ import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.core.common.viewmodel.scopedViewModel
 import com.archstarter.core.common.wallpaper.DaySlot
+import com.archstarter.core.common.wallpaper.RotationInterval
 import com.archstarter.core.common.wallpaper.WallpaperPreferencesRepository
 import com.archstarter.core.common.wallpaper.WallpaperScheduleMode
 import com.archstarter.core.common.wallpaper.WallpaperSettings
@@ -89,6 +90,7 @@ class WallpaperHomeViewModel @AssistedInject constructor(
             val description = when (settings.scheduleMode) {
                 WallpaperScheduleMode.SOLAR -> solarDescription(slot)
                 WallpaperScheduleMode.FIXED -> "Starts at ${formatMinutes(settings.slotSchedules.getValue(slot))}"
+                WallpaperScheduleMode.ROTATING -> "Part of a rotation that advances every ${formatRotation(settings.rotationInterval)}"
             }
             SlotCardState(
                 slot = slot,
@@ -105,6 +107,8 @@ class WallpaperHomeViewModel @AssistedInject constructor(
                 DaySlot.values().joinToString(separator = " → ") { slot ->
                     "${slot.displayName} ${formatMinutes(settings.slotSchedules.getValue(slot))}"
                 }
+            WallpaperScheduleMode.ROTATING ->
+                "Cycles through Morning → Day → Evening → Night every ${formatRotation(settings.rotationInterval)}"
         }
         return WallpaperHomeState(
             slots = slots,
@@ -127,6 +131,11 @@ class WallpaperHomeViewModel @AssistedInject constructor(
         DaySlot.DAY -> "Runs from sunrise to sunset"
         DaySlot.EVENING -> "Follows sunset through twilight"
         DaySlot.NIGHT -> "Covers the darkest hours"
+    }
+
+    private fun formatRotation(interval: RotationInterval): String {
+        val plural = if (interval.value == 1) interval.unit.displayName.dropLast(1) else interval.unit.displayName
+        return "${interval.value} $plural"
     }
 
     @AssistedFactory

--- a/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
+++ b/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
@@ -2,6 +2,7 @@ package com.archstarter.feature.settings.api
 
 import com.archstarter.core.common.presenter.ParamInit
 import com.archstarter.core.common.wallpaper.DaySlot
+import com.archstarter.core.common.wallpaper.RotationIntervalUnit
 import com.archstarter.core.common.wallpaper.WallpaperScheduleMode
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
@@ -15,10 +16,16 @@ data class ScheduleSlotUi(
     val startMinutes: Int,
 )
 
+data class RotationIntervalUi(
+    val value: Int = 6,
+    val unit: RotationIntervalUnit = RotationIntervalUnit.HOURS,
+)
+
 data class SettingsState(
     val scheduleMode: WallpaperScheduleMode = WallpaperScheduleMode.SOLAR,
     val slots: List<ScheduleSlotUi> = emptyList(),
     val description: String = "",
+    val rotationInterval: RotationIntervalUi = RotationIntervalUi(),
 )
 
 interface SettingsPresenter : ParamInit<Unit> {
@@ -26,4 +33,6 @@ interface SettingsPresenter : ParamInit<Unit> {
     fun onScheduleModeSelected(mode: WallpaperScheduleMode)
     fun onSlotTimeSelected(slot: DaySlot, minutes: Int)
     fun onResetDefaults()
+    fun onRotationIntervalValueChanged(value: Int)
+    fun onRotationIntervalUnitSelected(unit: RotationIntervalUnit)
 }


### PR DESCRIPTION
## Summary
- add a timer-driven ROTATING schedule mode with interval storage and computation
- expose rotation interval controls in the settings presenter, state, and compose UI
- surface rotating schedule descriptions in the catalog and update wallpaper selection logic

## Testing
- ./gradlew :core:common:testDebugUnitTest --console=plain --no-daemon


------
https://chatgpt.com/codex/tasks/task_e_68e23193872083289539f423aee18349