### PR TITLE
Clean up manifest package declarations after package rename

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
 }
 
 android {
-  namespace = "com.archstarter.app"
+  namespace = "com.dmitriisamoilenko.daynightwallpaper"
   compileSdk = 35
   defaultConfig {
-    applicationId = "com.archstarter.app"
+    applicationId = "com.dmitriisamoilenko.daynightwallpaper"
     minSdk = 33
     targetSdk = 35
     versionCode = 1

--- a/app/src/androidTest/java/com/dmitriisamoilenko/daynightwallpaper/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/dmitriisamoilenko/daynightwallpaper/MainActivityTest.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.archstarter.app">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission
         android:name="android.permission.BIND_WALLPAPER"
@@ -8,7 +7,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application
-        android:name=".MyApp"
+        android:name="com.dmitriisamoilenko.daynightwallpaper.MyApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
@@ -16,7 +15,7 @@
         android:label="DayNight Video Wallpaper"
         android:theme="@style/Theme.DayNightVideoWallpaper">
         <activity
-            android:name=".MainActivity"
+            android:name="com.dmitriisamoilenko.daynightwallpaper.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -25,7 +24,7 @@
         </activity>
 
         <service
-            android:name=".DayNightWallpaperService"
+            android:name="com.dmitriisamoilenko.daynightwallpaper.DayNightWallpaperService"
             android:label="DayNight Video Wallpaper"
             android:permission="android.permission.BIND_WALLPAPER"
             android:exported="true">

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppBridgeModule.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppBridgeModule.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import com.archstarter.core.common.app.App
 import dagger.Module

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppComponent.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppComponent.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import com.archstarter.core.common.app.App
 import com.archstarter.core.common.app.AppScope

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppEntryPoint.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppEntryPoint.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import com.archstarter.core.common.app.App
 import dagger.hilt.EntryPoint

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppScopeManager.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/AppScopeManager.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import com.archstarter.core.common.app.App
 import javax.inject.Inject

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/DayNightWallpaperService.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/DayNightWallpaperService.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import android.service.wallpaper.WallpaperService
 import android.view.SurfaceHolder

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/HiltPresenterResolver.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/HiltPresenterResolver.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import androidx.compose.runtime.Composable
 import com.archstarter.core.common.presenter.ParamInit

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/InternalApp.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/InternalApp.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import javax.inject.Qualifier
 

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/MyApp.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/MyApp.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import android.app.Application
 import dagger.hilt.android.HiltAndroidApp

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/Nav.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/Nav.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/NavigationActions.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/NavigationActions.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import android.app.WallpaperManager
 import android.content.ComponentName

--- a/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/PresenterModule.kt
+++ b/app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/PresenterModule.kt
@@ -1,4 +1,4 @@
-package com.archstarter.app
+package com.dmitriisamoilenko.daynightwallpaper
 
 import com.archstarter.core.common.presenter.PresenterProvider
 import dagger.Module

--- a/core/designsystem/src/main/AndroidManifest.xml
+++ b/core/designsystem/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.core.designsystem"/>
+<manifest />

--- a/feature/catalog/impl/src/main/AndroidManifest.xml
+++ b/feature/catalog/impl/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.catalog.impl"/>
+<manifest />

--- a/feature/catalog/ui/src/main/AndroidManifest.xml
+++ b/feature/catalog/ui/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.catalog.ui"/>
+<manifest />

--- a/feature/onboarding/impl/src/main/AndroidManifest.xml
+++ b/feature/onboarding/impl/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.onboarding.impl"/>
+<manifest />

--- a/feature/onboarding/ui/src/main/AndroidManifest.xml
+++ b/feature/onboarding/ui/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.onboarding.ui"/>
+<manifest />

--- a/feature/settings/impl/src/main/AndroidManifest.xml
+++ b/feature/settings/impl/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.settings.impl"/>
+<manifest />

--- a/feature/settings/ui/src/main/AndroidManifest.xml
+++ b/feature/settings/ui/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.archstarter.feature.settings.ui"/>
+<manifest />

--- a/tomulyiplatformroadmap.md
+++ b/tomulyiplatformroadmap.md
@@ -6,7 +6,7 @@ This roadmap grows **android-compose-arch-starter** from an Android-only experie
 
 | Area | What exists today |
 | --- | --- |
-| Android entry point | `app/src/main/java/com/archstarter/app/MainActivity` drives `AppNavHost` with `androidx.navigation.compose` and wires presenters via `HiltPresenterResolver`, `AppScopeManager`, and the Hilt multibindings in `PresenterModule.kt`.
+| Android entry point | `app/src/main/java/com/dmitriisamoilenko/daynightwallpaper/MainActivity` drives `AppNavHost` with `androidx.navigation.compose` and wires presenters via `HiltPresenterResolver`, `AppScopeManager`, and the Hilt multibindings in `PresenterModule.kt`.
 | Presenter plumbing | `core/common` packages (`presenter/`, `scope/`, `app/`, `viewmodel/`) expose `ParamInit`, Hilt-friendly `PresenterProvider`, and Android `ViewModel` bridges such as `MagicViewModel` and `ScreenVmFactory`.
 | UI system | `core/designsystem/src/main/java/com/archstarter/core/designsystem/Theme.kt` and `LiquidGlass.kt` provide Compose theming, but the module is Android-only.
 | Feature split | Each feature keeps `api`, `ui`, and `impl` Android library modules. For example, `feature/catalog/ui/CatalogScreen.kt` consumes `collectAsStateWithLifecycle` while `feature/catalog/impl/data/ArticleRepository.kt` builds Retrofit + Room stacks and registers them through Hilt modules inside `CatalogImpl.kt`.


### PR DESCRIPTION
## Summary
- remove obsolete `package` attributes from Android library manifests so Gradle namespaces drive the generated package names
- fully qualify the application components in the app manifest to match the new `com.dmitriisamoilenko.daynightwallpaper` package

## Testing
- `ANDROID_HOME=$PWD/android-sdk ANDROID_SDK_ROOT=$PWD/android-sdk ./gradlew --console=plain :app:compileDebugKotlin` *(passes once the local SDK is provisioned)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c515d6708328b839ab538e68ff71